### PR TITLE
Feat: Enable hosting app in any route, with easy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Your hosting environment should make the Conductor Server API available on the s
 
 See `docker/serverAndUI` for an `nginx` based example.
 
+#### Different host path
+The static UI would work when rendered from any host.
+The default is '/'. You can customize this by setting the 'homepage' field in package.json
+Refer
+- https://docs.npmjs.com/cli/v9/configuring-npm/package-json#homepage
+- https://create-react-app.dev/docs/deployment/#building-for-relative-paths
+
 ### Customization Hooks
 
 For ease of maintanence, a number of touch points for customization have been removed to `/plugins`.

--- a/src/components/AppLogo.jsx
+++ b/src/components/AppLogo.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
+import { useAppContext } from "../export";
+import { cleanDuplicateSlash } from "./context/DefaultAppContextProvider";
 
 const useStyles = makeStyles((theme) => ({
   logo: {
@@ -11,5 +13,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function AppLogo() {
   const classes = useStyles();
-  return <img src="/logo.svg" alt="Conductor" className={classes.logo} />;
+  const { basename } = useAppContext();
+  const logoPath = basename + '/logo.svg';
+  return <img src={cleanDuplicateSlash(logoPath)} alt="Conductor" className={classes.logo} />;
 }

--- a/src/components/context/DefaultAppContextProvider.jsx
+++ b/src/components/context/DefaultAppContextProvider.jsx
@@ -1,7 +1,10 @@
 import handleError from "../../utils/handleError";
 import AppContext from "./AppContext";
+import { isEmpty as _isEmpty } from "lodash";
 
 export default function DefaultAppContextProvider({ ...props }) {
+  const basename = _isEmpty(props.basename) ? '/' : props.basename;
+  
   return (
     <AppContext.Provider
       value={{
@@ -11,11 +14,12 @@ export default function DefaultAppContextProvider({ ...props }) {
         customTypeRenderers: {},
         customExecutionSummaryRows: [],
         customTaskSummaryRows: [],
+        basename,
         fetchWithContext: function (path, fetchParams) {
           const newParams = { ...fetchParams };
 
-          const newPath = `/api/${path}`;
-          const cleanPath = newPath.replace(/([^:]\/)\/+/g, "$1"); // Cleanup duplicated slashes
+          const newPath = basename + `/api/${path}`;
+          const cleanPath = cleanDuplicateSlash(newPath); // Cleanup duplicated slashes
 
           return fetch(cleanPath, newParams).then(handleError);
         },
@@ -23,4 +27,8 @@ export default function DefaultAppContextProvider({ ...props }) {
       {...props}
     />
   );
+}
+
+export function cleanDuplicateSlash(path) {
+  return path.replace(/([^:]\/)\/+/g, "$1");
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,9 @@ import { BrowserRouter } from "react-router-dom";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
+import { isEmpty as _isEmpty } from 'lodash';
+import packageJson from '../package.json';
+
 import DefaultAppContextProvider from "./components/context/DefaultAppContextProvider";
 
 const queryClient = new QueryClient({
@@ -19,11 +22,18 @@ const queryClient = new QueryClient({
   },
 });
 
+
+let basename = '/';
+try{
+  basename = new URL(packageJson.homepage).pathname;
+} catch(e) {}
+basename = _isEmpty(basename) ? '/' : basename;
+
 ReactDOM.render(
   <React.StrictMode>
     <ThemeProvider>
-      <BrowserRouter>
-        <DefaultAppContextProvider>
+      <BrowserRouter basename={basename}>
+        <DefaultAppContextProvider basename={basename}>
           <QueryClientProvider client={queryClient}>
             <CssBaseline />
             <ReactQueryDevtools />


### PR DESCRIPTION
Right now, Conductor UI is optimized to work when it is hosted at '/'.

With this PR, Conductor UI can be hosted at any homepage/route.
Changes are to
1. API calls from React
2. logo.svg call from React
3. Browser side internal Routing in React

This PR also makes it easy for clients to configure the homepage/route (the route on which the static app is hosted), by making use of the same field that react-scripts looks for, when building the code into bundles - the `homepage` field in `package.json`.