### PR TITLE
Vary styling of reason for incompletion notice based on workflow status

### DIFF
--- a/src/pages/execution/ExecutionHeader.tsx
+++ b/src/pages/execution/ExecutionHeader.tsx
@@ -93,13 +93,20 @@ export default function ExecutionHeader({
         )}
       </div>
       {execution.reasonForIncompletion && (
-        <Alert
-          severity={execution.status === "FAILED" ? "error" : "info"}
-          style={{ margin: "0 20px 20px 20px" }}
-        >
-          {execution.reasonForIncompletion}
-        </Alert>
-      )}
+  <Alert
+    severity={
+      execution.status === "FAILED"
+        ? "error"
+        : execution.status === "COMPLETED"
+        ? "success"
+        : "info"
+    }
+    style={{ margin: "0 20px 20px 20px" }}
+  >
+    {execution.reasonForIncompletion}
+  </Alert>
+)}
+
     </div>
   );
 }

--- a/src/pages/execution/ExecutionHeader.tsx
+++ b/src/pages/execution/ExecutionHeader.tsx
@@ -93,20 +93,19 @@ export default function ExecutionHeader({
         )}
       </div>
       {execution.reasonForIncompletion && (
-  <Alert
-    severity={
-      execution.status === "FAILED"
-        ? "error"
-        : execution.status === "COMPLETED"
-        ? "success"
-        : "info"
-    }
-    style={{ margin: "0 20px 20px 20px" }}
-  >
-    {execution.reasonForIncompletion}
-  </Alert>
-)}
-
+        <Alert
+          severity={
+            execution.status === "FAILED"
+              ? "error"
+              : execution.status === "COMPLETED"
+              ? "success"
+              : "info"
+          }
+          style={{ margin: "0 20px 20px 20px" }}
+        >
+          {execution.reasonForIncompletion}
+        </Alert>
+      )}
     </div>
   );
 }

--- a/src/pages/execution/ExecutionHeader.tsx
+++ b/src/pages/execution/ExecutionHeader.tsx
@@ -93,7 +93,10 @@ export default function ExecutionHeader({
         )}
       </div>
       {execution.reasonForIncompletion && (
-        <Alert severity="error" style={{ margin: "0 20px 20px 20px" }}>
+        <Alert
+          severity={execution.status === "FAILED" ? "error" : "info"}
+          style={{ margin: "0 20px 20px 20px" }}
+        >
           {execution.reasonForIncompletion}
         </Alert>
       )}


### PR DESCRIPTION
Show a success alert when workflow status is COMPLETED
<img width="1654" alt="Screenshot 2023-07-26 at 1 06 28 PM" src="https://github.com/Netflix/conductor-ui/assets/140001288/bf5f1084-6a70-4623-b618-80e7abf3bd50">

Show an error alert when workflow status is FAILED
<img width="1647" alt="Screenshot 2023-07-26 at 11 49 15 AM" src="https://github.com/Netflix/conductor-ui/assets/140001288/6a87fa21-4c6d-43c2-a9c5-f4837e998620">

In all the other workflow status cases (IN_PROGRESS), show an info alert (although now there should be no message showing up in this case